### PR TITLE
fix: 'NULL' in SQL when using 'null_percentage'

### DIFF
--- a/tablefaker/tablefaker.py
+++ b/tablefaker/tablefaker.py
@@ -275,6 +275,8 @@ class TableFaker:
             for value in row:
                 if value is None:
                     value_list.append("NULL")
+                elif value is pd.NA:
+                    value_list.append("NULL")
                 elif isinstance(value, (str, date, datetime)):
                     escaped = str(value).replace("'", "''")
                     value_list.append(f"'{escaped}'")

--- a/tests/test_code_review_fixes.py
+++ b/tests/test_code_review_fixes.py
@@ -224,6 +224,27 @@ class TestSQLExport:
         content = sql_file.read_text()
         assert "INSERT INTO [schema].[dbo].[orders]" in content
 
+    def test_sql_export_has_nulls_with_null_percentage(self, tmp_path):
+        cfg = {
+            "version": 1,
+            "config": {"locale": "en_US", "seed": 19},
+            "tables": [
+                {
+                    "table_name": "[schema].[dbo].[orders]",
+                    "row_count": 5,
+                    "columns": [
+                        {"column_name": "order_id", "data": "row_id"},
+                        {"column_name": "order_date", "data": "fake.date()", "null_percentage": 0.5}
+                    ],
+                }
+            ],
+        }
+        result = tablefaker.to_sql(cfg, str(tmp_path))
+        sql_file = list(tmp_path.glob("*.sql"))[0]
+        content = sql_file.read_text()
+        assert "NULL" in content
+
+
 
 # ---------------------------------------------------------------------------
 # null_percentage applies correctly (is None comparison)


### PR DESCRIPTION
## Issue

Currently when using the `null_percentage` column configuration option:

```yaml
  - column_name: order_date
    data: fake.date()
    null_percentage: 0.5
```

the exported SQL has values `<NA>` where `NULL` should be.  This issue can be recreated with the following script:

```Python
from glob import glob
from os import mkdir, path, remove

import tablefaker

if path.exists("/tmp/tf"):
    sql_files = glob("/tmp/tf/*.sql")
    for f in sql_files:
        remove(f)
else:
    mkdir("/tmp/tf")

cfg = {
    "version": 1,
    "config": {"locale": "en_US", "seed": 19},
    "tables": [
        {
            "table_name": "[schema].[dbo].[orders]",
            "row_count": 5,
            "columns": [
                {"column_name": "order_id", "data": "row_id"},
                {"column_name": "order_date", "data": "fake.date()", "null_percentage": 0.5}
            ],
        }
    ],
}
result = tablefaker.to_sql(cfg, "/tmp/tf/")
sql_file = glob("/tmp/tf/*.sql")[0]

with open(sql_file, 'r') as fd:
    lines = fd.readlines()

print(lines)
assert any(["NULL" in line for line in lines])
```

## Fix

This PR adds a check for the `pandas.NA` value when exporting to SQL so that it can be substituted for `NULL` as well as a unit test to ensure this behavior.